### PR TITLE
Change chronological order of FRC competitions

### DIFF
--- a/components/Frc.js
+++ b/components/Frc.js
@@ -33,14 +33,14 @@ export default function Frc(props) {
                             slug={props.slug}
                         />
                         <CompetitionCard 
-                            header="Canadian Pacific Regionals 2019"
-                            description="In their inaugural season, the Reynolds Reybots competed at the Save-On Memorial Center. The Reybots were ranked 31 st after Qualifications with a record of 4-7-0. 7787 won the Rookie All-Star award and an invitation to the FIRST World Robotics Championship in Houston, Texas."
+                            header="FIRST World Championship 2019"
+                            description="In the Hopper Division, the Reynolds Reybots were 54 th with a record of 3-7-0."
                             link="https://www.thebluealliance.com/team/7787/2019"
                             slug={props.slug}
                         />
                         <CompetitionCard 
-                            header="FIRST World Championship 2019"
-                            description="In the Hopper Division, the Reynolds Reybots were 54 th with a record of 3-7-0."
+                            header="Canadian Pacific Regionals 2019"
+                            description="In their inaugural season, the Reynolds Reybots competed at the Save-On Memorial Center. The Reybots were ranked 31 st after Qualifications with a record of 4-7-0. 7787 won the Rookie All-Star award and an invitation to the FIRST World Robotics Championship in Houston, Texas."
                             link="https://www.thebluealliance.com/team/7787/2019"
                             slug={props.slug}
                         />


### PR DESCRIPTION
Hi!

Just a small change assuming that you intend to maintain a chronological order for the competitions (the FRC World Championships came after the Regionals). I guess you will want to add this year's championship but I'll leave that one up to you! (Congrats of getting there btw!)

Also, as a small note as the previous website maintainer: thank you for the redesign, it looks awesome and it definitely was in a dire need of a redesign (I also love that you used Coast Capital Savings' logo for drafting the website in Figma 🤣 , I did the same 4 years ago).

Keep up the good work!