### PR TITLE
Fixed special characters in About us section

### DIFF
--- a/components/HomeComponent.js
+++ b/components/HomeComponent.js
@@ -130,9 +130,9 @@ export default function HomeComponent() {
                         <p className="aboutDescription">
                             The Reynolds Reybots club is located in Victoria, BC at Reynolds Secondary School.
                             Our team is not just about building robots.
-                            It's about working in the community, teaching the fundamentals of STEM and inspiring others!
+                            It&apos;s about working in the community, teaching the fundamentals of STEM and inspiring others!
                             Every year we come together and create a common goal for the season.
-                            This year it's 'Improve our skills, develop our documentation and award focused aspects.'
+                            This year it&apos;s &lsqo; Improve our skills, develop our documentation and award focused aspects.&rsqo;
                             All of our students work hard to achieve the goal and learn so much along the way by getting hands-on with actually building something, collaborating with others, and sometimes working on the more business side of things! 
                             Many of our students grow up and decide to pursue passions in the area of STEM or Business, or just use the skills they used while on the team like creativity and collaboration!
                         </p>


### PR DESCRIPTION
Apostrophes and Quotations need to be escaped with the &ITEM; syntax.